### PR TITLE
Adds multi-stage builds (POSTPONED)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,16 @@
-FROM node:8.7.0-alpine
+FROM node:9.2.1-alpine as builder
+RUN apk update && apk upgrade && \
+    apk add --no-cache git
+WORKDIR /build
+ADD ./package.json ./.babelrc ./
+ADD ./src ./src
+RUN yarn
+RUN yarn build
+
+FROM node:9.2.1-alpine
 RUN apk update && apk upgrade && \
     apk add --no-cache git
 WORKDIR /app
-COPY package.json /app
-RUN yarn
-COPY . /app
+COPY --from=builder ./build/dist ./dist
+COPY  ./.env ./.watch.yml ./package.json ./
+RUN yarn --production


### PR DESCRIPTION
This PR uses the new docker multi-stage feature in order to build the project then run it directly without the need for babel nor devDependancies. 
It will not be merged now until all systems are updated with version > 17 